### PR TITLE
Fix accidental scrolling in Parameter-Comboboxes

### DIFF
--- a/mne_pipeline_hd/development/check_ressources.py
+++ b/mne_pipeline_hd/development/check_ressources.py
@@ -20,7 +20,8 @@ from mne_pipeline_hd.functions import operations, plot
 # changing func_args in functions.csv)
 with resources.path('mne_pipeline_hd.resource',
                     'functions.csv') as pd_funcs_path:
-    pd_funcs = pd.read_csv(str(pd_funcs_path), sep=';', index_col=0)
+    pd_funcs = pd.read_csv(str(pd_funcs_path), sep=';', index_col=0,
+                           na_values=[''], keep_default_na=False)
 
 for func_name in pd_funcs.index:
     module_name = pd_funcs.loc[func_name, 'module']

--- a/mne_pipeline_hd/functions/operations.py
+++ b/mne_pipeline_hd/functions/operations.py
@@ -1017,8 +1017,9 @@ def setup_src(fsmri, src_spacing, surface, n_jobs):
 
 def setup_vol_src(fsmri, vol_src_spacing):
     bem = fsmri.load_bem_solution()
-    vol_src = mne.setup_volume_source_space(fsmri.name, pos=vol_src_spacing, bem=bem,
-                                   subjects_dir=fsmri.subjects_dir)
+    vol_src = mne.setup_volume_source_space(
+        fsmri.name, pos=vol_src_spacing, bem=bem,
+        subjects_dir=fsmri.subjects_dir)
     fsmri.save_volume_source_space(vol_src)
 
 

--- a/mne_pipeline_hd/gui/base_widgets.py
+++ b/mne_pipeline_hd/gui/base_widgets.py
@@ -18,7 +18,7 @@ from PyQt5.QtWidgets import (QAbstractItemView, QApplication, QDialog,
                              QHBoxLayout, QLabel,
                              QListView, QPushButton, QScrollArea, QSizePolicy,
                              QSpinBox, QTabWidget, QTableView, QTreeView,
-                             QVBoxLayout, QWidget)
+                             QVBoxLayout, QWidget, QComboBox)
 
 from mne_pipeline_hd import _object_refs
 from mne_pipeline_hd.gui.gui_utils import get_user_input_string
@@ -1157,6 +1157,16 @@ class DictTree(Base):
                          drag_drop=drag_drop,
                          parent=parent,
                          title=title, verbose=verbose)
+
+
+class ComboBox(QComboBox):
+    def __init__(self, scrollable=False, **kwargs):
+        self.scrollable = scrollable
+        super().__init__(**kwargs)
+
+    def wheelEvent(self, event):
+        if self.scrollable:
+            super().wheelEvent(event)
 
 
 class SimpleDialog(QDialog):

--- a/mne_pipeline_hd/gui/function_widgets.py
+++ b/mne_pipeline_hd/gui/function_widgets.py
@@ -1099,9 +1099,13 @@ class ImportFuncs(QDialog):
                 pd_params_path = join(self.cf.file_path.parent,
                                       f'{self.cf.pkg_name}_parameters.csv')
                 self.cf.add_pd_funcs = pd.read_csv(pd_funcs_path,
-                                                   sep=';', index_col=0)
+                                                   sep=';', index_col=0,
+                                                   na_values=[''],
+                                                   keep_default_na=False)
                 self.cf.add_pd_params = pd.read_csv(pd_params_path,
-                                                    sep=';', index_col=0)
+                                                    sep=';', index_col=0,
+                                                    na_values=[''],
+                                                    keep_default_na=False)
 
                 # Can be removed soon, when nobody uses
                 # old packages anymore (10.11.2020)
@@ -1404,7 +1408,8 @@ class SavePkgDialog(QDialog):
                          f'{self.cf_dialog.pkg_name}_parameters.csv')
                 if isfile(pd_funcs_path):
                     read_pd_funcs = pd.read_csv(pd_funcs_path, sep=';',
-                                                index_col=0)
+                                                index_col=0, na_values=[''],
+                                                keep_default_na=False)
                     # Replace indexes from file with same name
                     drop_funcs = [f for f in read_pd_funcs.index
                                   if f in final_add_pd_funcs.index]
@@ -1413,7 +1418,8 @@ class SavePkgDialog(QDialog):
                         read_pd_funcs.append(final_add_pd_funcs)
                 if isfile(pd_params_path):
                     read_pd_params = pd.read_csv(pd_params_path, sep=';',
-                                                 index_col=0)
+                                                 index_col=0, na_values=[''],
+                                                 keep_default_na=False)
                     # Replace indexes from file with same name
                     drop_params = [p for p in read_pd_params.index if
                                    p in final_add_pd_params.index]

--- a/mne_pipeline_hd/gui/parameter_widgets.py
+++ b/mne_pipeline_hd/gui/parameter_widgets.py
@@ -26,7 +26,8 @@ from vtkmodules.vtkRenderingCore import vtkCellPicker
 
 from mne_pipeline_hd import _object_refs
 from mne_pipeline_hd.gui.base_widgets import (CheckList, EditDict, EditList,
-                                              SimpleList, SimpleDialog)
+                                              SimpleList, SimpleDialog,
+                                              ComboBox)
 from mne_pipeline_hd.gui.dialogs import CheckListDlg
 from mne_pipeline_hd.gui.gui_utils import (get_std_icon, WorkerDialog,
                                            get_exception_tuple,
@@ -601,7 +602,7 @@ class ComboGui(Param):
         """
         super().__init__(**kwargs)
         self.options = options
-        self.param_widget = QComboBox()
+        self.param_widget = ComboBox(scrollable=False)
         self.param_widget.activated.connect(self._get_param)
         for option in self.options:
             if isinstance(self.options, dict):

--- a/mne_pipeline_hd/gui/parameter_widgets.py
+++ b/mne_pipeline_hd/gui/parameter_widgets.py
@@ -1825,7 +1825,7 @@ class ParametersDock(QDockWidget):
                     err_tuple = get_exception_tuple()
                     raise RuntimeError(
                         f'Initialization of Parameter-Widget "{idx}" '
-                        f'with value {self.param_guis[idx].param_value} '
+                        f'with value {default} '
                         f'failed:\n'
                         f'{err_tuple[1]}')
 

--- a/mne_pipeline_hd/gui/parameter_widgets.py
+++ b/mne_pipeline_hd/gui/parameter_widgets.py
@@ -904,10 +904,12 @@ class DictGui(Param):
         self.init_ui(dict_layout)
 
     def set_value(self, value):
-        if value is not None:
+        # In CI tests, apparently None is read as NaN from .csv, can be
+        # reversed to specific None check when moving away from .csv and pandas
+        if pd.notna(value):
             self.cached_value = value
         self.check_groupbox_state()
-        if value is not None:
+        if pd.notna(value):
             if self.param_unit:
                 val_str = ', '.join(
                     [f'{k} {self.param_unit}: {v} {self.param_unit}'
@@ -1825,7 +1827,7 @@ class ParametersDock(QDockWidget):
                     err_tuple = get_exception_tuple()
                     raise RuntimeError(
                         f'Initialization of Parameter-Widget "{idx}" '
-                        f'with value {default} '
+                        f'with value={default} '
                         f'failed:\n'
                         f'{err_tuple[1]}')
 

--- a/mne_pipeline_hd/gui/parameter_widgets.py
+++ b/mne_pipeline_hd/gui/parameter_widgets.py
@@ -910,11 +910,10 @@ class DictGui(Param):
         if value is not None:
             if self.param_unit:
                 val_str = ', '.join(
-                    [f'{key} {self.param_unit}: {value} {self.param_unit}'
-                     for key, value in value.items()])
+                    [f'{k} {self.param_unit}: {v} {self.param_unit}'
+                     for k, v in value.items()])
             else:
-                val_str = ', '.join([f'{key}: {value}' for key, value in
-                                     value.items()])
+                val_str = ', '.join([f'{k}: {v}' for k, v in value.items()])
             if len(val_str) > self.value_string_length:
                 self.value_label.setText(
                     f'{val_str[:self.value_string_length]} ...')
@@ -1825,7 +1824,7 @@ class ParametersDock(QDockWidget):
                 except:  # noqa: E722
                     err_tuple = get_exception_tuple()
                     raise RuntimeError(
-                        f'Initiliazation of Parameter-Widget "{idx}" failed:\n'
+                        f'Initialization of Parameter-Widget "{idx}" failed:\n'
                         f'{err_tuple[1]}')
 
                 layout.addWidget(self.param_guis[idx])

--- a/mne_pipeline_hd/gui/parameter_widgets.py
+++ b/mne_pipeline_hd/gui/parameter_widgets.py
@@ -1824,7 +1824,9 @@ class ParametersDock(QDockWidget):
                 except:  # noqa: E722
                     err_tuple = get_exception_tuple()
                     raise RuntimeError(
-                        f'Initialization of Parameter-Widget "{idx}" failed:\n'
+                        f'Initialization of Parameter-Widget "{idx}" '
+                        f'with value {self.param_guis[idx].param_value} '
+                        f'failed:\n'
                         f'{err_tuple[1]}')
 
                 layout.addWidget(self.param_guis[idx])

--- a/mne_pipeline_hd/gui/parameter_widgets.py
+++ b/mne_pipeline_hd/gui/parameter_widgets.py
@@ -904,12 +904,10 @@ class DictGui(Param):
         self.init_ui(dict_layout)
 
     def set_value(self, value):
-        # In CI tests, apparently None is read as NaN from .csv, can be
-        # reversed to specific None check when moving away from .csv and pandas
-        if pd.notna(value):
+        if value is not None:
             self.cached_value = value
         self.check_groupbox_state()
-        if pd.notna(value):
+        if value is not None:
             if self.param_unit:
                 val_str = ', '.join(
                     [f'{k} {self.param_unit}: {v} {self.param_unit}'

--- a/mne_pipeline_hd/pipeline/controller.py
+++ b/mne_pipeline_hd/pipeline/controller.py
@@ -100,14 +100,16 @@ class Controller:
         with resources.path('mne_pipeline_hd.resource',
                             'functions.csv') as pd_funcs_path:
             self.pd_funcs = pd.read_csv(str(pd_funcs_path), sep=';',
-                                        index_col=0)
+                                        index_col=0, na_values=[''],
+                                        keep_default_na=False)
 
         # Pandas-DataFrame for contextual data of parameters
         # for basic functions (included with program)
         with resources.path('mne_pipeline_hd.resource',
                             'parameters.csv') as pd_params_path:
             self.pd_params = pd.read_csv(str(pd_params_path), sep=';',
-                                         index_col=0)
+                                         index_col=0, na_values=[''],
+                                         keep_default_na=False)
 
         # Import the basic- and custom-function-modules
         self.import_custom_modules()
@@ -328,9 +330,13 @@ class Controller:
                 if len(file_dict['modules']) == correct_count:
                     try:
                         read_pd_funcs = pd.read_csv(functions_path,
-                                                    sep=';', index_col=0)
+                                                    sep=';', index_col=0,
+                                                    na_values=[''],
+                                                    keep_default_na=False)
                         read_pd_params = pd.read_csv(parameters_path,
-                                                     sep=';', index_col=0)
+                                                     sep=';', index_col=0,
+                                                     na_values=[''],
+                                                     keep_default_na=False)
                     except:  # noqa: E722
                         traceback.print_exc()
                     else:


### PR DESCRIPTION
This disables scrolling for Parameter-Comboboxes to avoid accidental change of parameters while scrolling through parameters.