### PR TITLE
feat: replace qdarkstyle with pyqtdarktheme and add 'auto' option

### DIFF
--- a/mne_pipeline_hd/__main__.py
+++ b/mne_pipeline_hd/__main__.py
@@ -87,6 +87,11 @@ def main():
 
     # Set Style and Window-Icon
     app_style = QS().value('app_style')
+
+    # Legacy 20230717
+    if app_style not in ['dark', 'light', 'auto']:
+        app_style = 'auto'
+
     if app_style == 'dark':
         qdarktheme.setup_theme('dark')
         icon_name = 'mne_pipeline_icon_dark.png'

--- a/mne_pipeline_hd/__main__.py
+++ b/mne_pipeline_hd/__main__.py
@@ -12,11 +12,10 @@ import os
 import sys
 from importlib import resources
 
-import qdarkstyle
+import qdarktheme
 from PyQt5.QtCore import QTimer, Qt
 from PyQt5.QtGui import QIcon, QFont
 from PyQt5.QtWidgets import QApplication
-from qdarkstyle import DarkPalette, LightPalette
 
 from mne_pipeline_hd.gui.gui_utils import StdoutStderrStream, UncaughtHook
 from mne_pipeline_hd.gui.welcome_window import WelcomeWindow
@@ -27,6 +26,8 @@ def main():
     app_name = 'mne-pipeline-hd'
     organization_name = 'marsipu'
     domain_name = 'https://github.com/marsipu/mne-pipeline-hd'
+
+    qdarktheme.enable_hi_dpi()
 
     app = QApplication.instance()
     if not app:
@@ -87,14 +88,18 @@ def main():
     # Set Style and Window-Icon
     app_style = QS().value('app_style')
     if app_style == 'dark':
-        app.setStyleSheet(qdarkstyle.load_stylesheet(palette=DarkPalette))
+        qdarktheme.setup_theme('dark')
         icon_name = 'mne_pipeline_icon_dark.png'
-    else:
+    elif app_style == 'light':
+        qdarktheme.setup_theme('light')
         icon_name = 'mne_pipeline_icon_light.png'
-        if app_style == 'light':
-            app.setStyleSheet(qdarkstyle.load_stylesheet(palette=LightPalette))
+    else:
+        qdarktheme.setup_theme('auto')
+        st = qdarktheme.load_stylesheet('auto')
+        if 'background:rgba(32, 33, 36, 1.000)' in st:
+            icon_name = 'mne_pipeline_icon_dark.png'
         else:
-            app.setStyle(app_style)
+            icon_name = 'mne_pipeline_icon_light.png'
 
     with resources.path('mne_pipeline_hd.resource', icon_name) as icon_path:
         app_icon = QIcon(str(icon_path))

--- a/mne_pipeline_hd/gui/dialogs.py
+++ b/mne_pipeline_hd/gui/dialogs.py
@@ -331,8 +331,8 @@ class AboutDialog(QDialog):
                'mne-python>Website</a>' \
                '<a href=https://github.com/mne-tools/mne-python>' \
                'GitHub</a><br>' \
-               '<a href=https://github.com/ColinDuquesnoy/' \
-               'QDarkStyleSheet>qdarkstyle</a><br>' \
+               '<a href=https://github.com/5yutan5/PyQtDarkTheme>' \
+               'pyqtdarktheme</a><br>' \
                '<br>' \
                '<b>Licensed under:</b><br>' \
                + license_text

--- a/mne_pipeline_hd/gui/parameter_widgets.py
+++ b/mne_pipeline_hd/gui/parameter_widgets.py
@@ -18,7 +18,7 @@ from PyQt5.QtWidgets import (QCheckBox, QComboBox, QDialog, QDoubleSpinBox,
                              QLineEdit, QPushButton, QSizePolicy, QSlider,
                              QSpinBox, QVBoxLayout, QWidget, QDockWidget,
                              QTabWidget, QScrollArea, QMessageBox,
-                             QStyleFactory, QColorDialog)
+                             QColorDialog)
 from mne.viz import Brain
 from mne_qt_browser._pg_figure import _get_color
 from vtkmodules.vtkCommonCore import vtkCommand
@@ -1900,7 +1900,7 @@ class SettingsDlg(QDialog):
                     'alias': 'Application Style',
                     'description': 'Changes the application style '
                                    '(Restart required).',
-                    'options': ['light', 'dark'] + QStyleFactory().keys(),
+                    'options': ['light', 'dark', 'auto'],
                 }
             },
             'app_font': {

--- a/mne_pipeline_hd/resource/default_settings.json
+++ b/mne_pipeline_hd/resource/default_settings.json
@@ -29,6 +29,6 @@
         "mne_path": "",
         "app_font": "AnyStyle",
         "app_font_size": 10,
-        "app_style": "Fusion"
+        "app_style": "auto"
     }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,7 @@
 PyQt5
 qtpy
 pyobjc-framework-Cocoa; sys_platform == "darwin"
-darkdetect
-qdarkstyle
+pyqtdarktheme
 
 # MNE-related
 mne


### PR DESCRIPTION
Replaces [qdarkstyle](https://github.com/ColinDuquesnoy/QDarkStyleSheet) with [pyqtdarktheme](https://github.com/5yutan5/PyQtDarkTheme).
This also adds the `auto`-option which detects the OS-Theme.