### PR TITLE
MNT: Remove dependency PyQtDarktheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ of [MNE-Python](https://mne.tools/stable/index.html)
 > February 2014, Pages 446-460, ISSN 1053-8119,
 > [DOI](https://doi.org/10.1016/j.neuroimage.2013.10.027)
 
-It was inspired by a pipeline
+It was originally inspired by a pipeline
 from [Lau M. Andersen](https://doi.org/10.3389/fnins.2018.00006)
 > Andersen LM. Group Analysis in MNE-Python of Evoked Responses from a Tactile
 > Stimulation Paradigm: A Pipeline for
@@ -91,6 +91,8 @@ integrates [autoreject](https://doi.org/10.1016/j.neuroimage.2017.06.030)
 > Gramfort. 2017.
 > “Autoreject: Automated artifact rejection for MEG and EEG data”. NeuroImage,
 > 159, 417-429.
+
+The Stylesheets for light and dark theme are derived and inspired from [PyQtDarkTheme](https://github.com/5yutan5/PyQtDarkTheme).
 
 Many ideas and basics for GUI-Programming where taken
 from [LearnPyQt](https://www.learnpyqt.com/) and numerous

--- a/mne_pipeline_hd/extra/dark_stylesheet.txt
+++ b/mne_pipeline_hd/extra/dark_stylesheet.txt
@@ -1,0 +1,178 @@
+QWidget {background:rgba(32, 33, 36, 1.000);color:rgba(228, 231, 235, 1.000);selection-color:rgba(228, 231, 235, 1.000);selection-background-color:rgba(95, 154, 244, 0.400)}
+QWidget:disabled {color:rgba(228, 231, 235, 0.400);selection-background-color:rgba(228, 231, 235, 0.200);selection-color:rgba(228, 231, 235, 0.400)}
+QWidget:focus {outline:none}
+QCheckBox:!window,QRadioButton:!window,QPushButton:!window,QLabel:!window,QLCDNumber:!window {background:transparent}
+QMdiSubWindow > QCheckBox:!window,QMdiSubWindow > QRadioButton:!window,QMdiSubWindow > QPushButton:!window,QMdiSubWindow > QLabel:!window,QMdiSubWindow > QLCDNumber:!window {background:rgba(32, 33, 36, 1.000)}
+QMainWindow::separator {width:4px;height:4px;background:rgba(63, 64, 66, 1.000)}
+QMainWindow::separator:hover,QMainWindow::separator:pressed {background:rgba(138, 180, 247, 1.000)}
+QToolTip {background:rgba(42, 43, 47, 1.000);color:rgba(228, 231, 235, 1.000);border: 0px}
+QSizeGrip {width:0;height:0;image:none}
+QStatusBar {background:rgba(42, 43, 46, 1.000)}
+QStatusBar::item {border:none}
+QStatusBar QWidget {background:transparent;padding:3px;border-radius:4px}
+QStatusBar > .QSizeGrip {padding:0}
+QStatusBar QWidget:hover {background:rgba(255, 255, 255, 0.133)}
+QStatusBar QWidget:pressed,QStatusBar QWidget:checked {background:rgba(255, 255, 255, 0.204)}
+QCheckBox,QRadioButton {border-top:2px solid transparent;border-bottom:2px solid transparent}
+QCheckBox:hover,QRadioButton:hover {border-bottom:2px solid rgba(138, 180, 247, 1.000)}
+QGroupBox {font-weight:bold;margin-top:8px;padding:2px 1px 1px 1px;border-radius:4px;border:1px solid rgba(63, 64, 66, 1.000)}
+QGroupBox::title {subcontrol-origin:margin;subcontrol-position:top left;left:7px;margin:0 2px 0 3px}
+QGroupBox:flat {border-color:transparent}
+QMenuBar {padding:2px;border-bottom:1px solid rgba(63, 64, 66, 1.000);background:rgba(32, 33, 36, 1.000)}
+QMenuBar::item {background:transparent;padding:4px}
+QMenuBar::item:selected {padding:4px;border-radius:4px;background:rgba(255, 255, 255, 0.145)}
+QMenuBar::item:pressed {padding:4px;margin-bottom:0;padding-bottom:0}
+QToolBar {padding:1px;font-weight:bold;spacing:2px;margin:1px;background:rgba(51, 51, 51, 1.000);border-style:none}
+QToolBar::separator {background:rgba(63, 64, 66, 1.000)}
+QToolBar::separator:horizontal {width:2px;margin:0 6px}
+QToolBar::separator:vertical {height:2px;margin:6px 0}
+QToolBar > QToolButton {background:transparent;padding:3px;border-radius:4px}
+QToolBar > QToolButton:hover,QToolBar > QToolButton::menu-button:hover {background:rgba(255, 255, 255, 0.133)}
+QToolBar > QToolButton::menu-button {border-top-right-radius:4px;border-bottom-right-radius:4px}
+QToolBar > QToolButton:pressed,QToolBar > QToolButton::menu-button:pressed:enabled,QToolBar > QToolButton:checked:enabled {background:rgba(255, 255, 255, 0.204)}
+QToolBar > QWidget {background:transparent}
+QMenu {background:rgba(42, 43, 47, 1.000);padding:8px 0; }
+QMenu::separator {margin:4px 0;height:1px;background:rgba(63, 64, 66, 1.000)}
+QMenu::item {padding:4px 19px}
+QMenu::item:selected {background:rgba(255, 255, 255, 0.133)}
+QMenu::icon {padding-left:10px;width:14px;height:14px}
+QScrollBar {background:rgba(255, 255, 255, 0.063);border-radius:4px;}
+QScrollBar:horizontal {height:14px;}
+QScrollBar:vertical {width:14px;}
+QScrollBar::handle {background:rgba(255, 255, 255, 0.188);border-radius:3px}
+QScrollBar::handle:hover {background:rgba(255, 255, 255, 0.271)}
+QScrollBar::handle:pressed {background:rgba(255, 255, 255, 0.376)}
+QScrollBar::handle:disabled {background:rgba(255, 255, 255, 0.082)}
+QScrollBar::handle:horizontal {min-width:8px;margin:4px 14px;}
+QScrollBar::handle:horizontal:hover {margin:2px 14px;}
+QScrollBar::handle:vertical {min-height:8px;margin:14px 4px;}
+QScrollBar::handle:vertical:hover {margin:14px 2px;}
+QScrollBar::sub-page,QScrollBar::add-page {background:transparent}
+QScrollBar::sub-line,QScrollBar::add-line {background:transparent;}
+QProgressBar {text-align:center;border:1px solid rgba(63, 64, 66, 1.000);border-radius:4px}
+QProgressBar::chunk {background:rgba(102, 159, 245, 1.000);border-radius:3px}
+QProgressBar::chunk:disabled {background:rgba(228, 231, 235, 0.200)}
+QPushButton {color:rgba(138, 180, 247, 1.000);border:1px solid rgba(63, 64, 66, 1.000);padding:4px 8px;border-radius:4px}
+QPushButton:flat,QPushButton:default {border:none;padding:5px 9px}
+QPushButton:default {color:rgba(32, 33, 36, 1.000);background:rgba(138, 180, 247, 1.000)}
+QPushButton:hover {background:rgba(102, 159, 245, 0.110)}
+QPushButton:pressed {background:rgba(87, 150, 244, 0.230)}
+QPushButton:checked:enabled {background:rgba(87, 150, 244, 0.230)}
+QPushButton:default:hover {background:rgba(117, 168, 246, 1.000)}
+QPushButton:default:pressed,QPushButton:default:checked {background:rgba(95, 154, 244, 1.000)}
+QPushButton:default:disabled,QPushButton:default:checked:disabled {background:rgba(228, 231, 235, 0.200)}
+QDialogButtonBox {dialogbuttonbox-buttons-have-icons:0}
+QDialogButtonBox QPushButton {min-width:65px}
+QToolButton {background:transparent;padding:5px;spacing:2px;border-radius:2px}
+QToolButton:hover,QToolButton::menu-button:hover {background:rgba(102, 159, 245, 0.110)}
+QToolButton:pressed,QToolButton:checked:pressed,QToolButton::menu-button:pressed:enabled {background:rgba(87, 150, 244, 0.230)}
+QToolButton:selected:enabled,QToolButton:checked:enabled {background:rgba(87, 150, 244, 0.230)}
+QToolButton::menu-arrow {image:unset}
+QToolButton[popupMode="1"] {padding-right:1px;margin-right:18px;border-top-right-radius:0;border-bottom-right-radius:0}
+QComboBox {min-height:1.5em;padding:0 8px 0 4px;background:rgba(63, 64, 66, 1.000);border:1px solid rgba(63, 64, 66, 1.000);border-radius:4px}
+QComboBox:focus,QComboBox:open {border-color:rgba(138, 180, 247, 1.000)}
+QComboBox::drop-down {margin:2px 2px 2px -6px;border-radius:4}
+QComboBox::drop-down:editable:hover {background:rgba(255, 255, 255, 0.145)}
+QComboBox::item:selected {border:none;background:rgba(66, 136, 242, 0.400);border-radius:4px}
+QComboBox QListView[frameShape="0"] {margin:0;padding:4px;background:rgba(42, 43, 47, 1.000);selection-background-color:rgba(66, 136, 242, 0.400); border-radius:0; }
+QComboBox QListView::item {border-radius:4px}
+QSlider {padding:2px 0}
+QSlider::groove {border-radius:2px}
+QSlider::groove:horizontal {height:4px}
+QSlider::groove:vertical {width:4px}
+QSlider::sub-page:horizontal,QSlider::add-page:vertical,QSlider::handle {background:rgba(138, 180, 247, 1.000)}
+QSlider::sub-page:horizontal:disabled,QSlider::add-page:vertical:disabled,QSlider::handle:disabled {background:rgba(228, 231, 235, 0.200)}
+QSlider::add-page:horizontal,QSlider::sub-page:vertical {background:rgba(228, 231, 235, 0.100)}
+QSlider::handle:hover,QSlider::handle:pressed {background:rgba(106, 161, 245, 1.000)}
+QSlider::handle:horizontal {width:16px;height:8px;margin:-6px 0;border-radius:8px}
+QSlider::handle:vertical {width:8px;height:16px;margin:0 -6px;border-radius:8px}
+QTabWidget::pane {border:1px solid rgba(63, 64, 66, 1.000);border-radius:4px}
+QTabBar {qproperty-drawBase:0}
+QTabBar::tab {padding:3px;border-style:solid}
+QTabBar::tab:hover,QTabBar::tab:selected:hover:enabled {background:rgba(255, 255, 255, 0.094)}
+QTabBar::tab:selected:enabled {color:rgba(138, 180, 247, 1.000);background:rgba(255, 255, 255, 0.000);border-color:rgba(138, 180, 247, 1.000)}
+QTabBar::tab:selected:disabled,QTabBar::tab:only-one:selected:enabled {border-color:rgba(63, 64, 66, 1.000)}
+QTabBar::tab:top {border-bottom-width:2px;margin:3px 6px 0 0;border-top-left-radius:2px;border-top-right-radius:2px}
+QTabBar::tab:bottom {border-top-width:2px;margin:0 6px 3px 0;border-bottom-left-radius:2px;border-bottom-right-radius:2px}
+QTabBar::tab:left {border-right-width:2px;margin:0 0 6px 3px;border-top-left-radius:2px;border-bottom-left-radius:2px}
+QTabBar::tab:right {border-left-width:2px;margin-bottom:6px;margin:0 3px 6px 0;border-top-right-radius:2px;border-bottom-right-radius:2px}
+QTabBar::tab:top:first,QTabBar::tab:top:only-one,QTabBar::tab:bottom:first,QTabBar::tab:bottom:only-one {margin-left:2px}
+QTabBar::tab:top:last,QTabBar::tab:top:only-one,QTabBar::tab:bottom:last,QTabBar::tab:bottom:only-one {margin-right:2px}
+QTabBar::tab:left:first,QTabBar::tab:left:only-one,QTabBar::tab:right:first,QTabBar::tab:right:only-one {margin-top:2px}
+QTabBar::tab:left:last,QTabBar::tab:left:only-one,QTabBar::tab:right:last,QTabBar::tab:right:only-one {margin-bottom:2px}
+QDockWidget {border:1px solid rgba(63, 64, 66, 1.000);border-radius:4px}
+QDockWidget::title {padding:3px;spacing:4px;background:rgba(22, 23, 25, 1.000)}
+QDockWidget::close-button,QDockWidget::float-button {border-radius:2px}
+QDockWidget::close-button:hover,QDockWidget::float-button:hover {background:rgba(102, 159, 245, 0.110)}
+QDockWidget::close-button:pressed,QDockWidget::float-button:pressed {background:rgba(87, 150, 244, 0.230)}
+QFrame {border:1px solid rgba(63, 64, 66, 1.000);padding:1px;border-radius:4px}
+.QFrame {padding:0}
+QFrame[frameShape="0"] {border-color:transparent;padding:0}
+.QFrame[frameShape="0"] {border:none}
+QFrame[frameShape="2"] {border-color:rgba(22, 23, 25, 1.000);background:rgba(22, 23, 25, 1.000)}
+QFrame[frameShape="4"] {max-height:2px;border:none;background:rgba(63, 64, 66, 1.000)}
+QFrame[frameShape="5"] {max-width:2px;border:none;background:rgba(63, 64, 66, 1.000)}
+QLCDNumber {min-width:2em;margin:2px}
+QToolBox::tab {background:rgba(22, 23, 25, 1.000);border-bottom:2px solid rgba(63, 64, 66, 1.000);border-top-left-radius:4px;border-top-right-radius:4px}
+QToolBox::tab:selected:enabled {border-bottom-color:rgba(138, 180, 247, 1.000)}
+QSplitter::handle {background:rgba(63, 64, 66, 1.000);margin:1px 3px}
+QSplitter::handle:hover {background:rgba(138, 180, 247, 1.000)}
+QSplitterHandle::item:hover {}
+QAbstractScrollArea {margin:1px}
+QAbstractScrollArea::corner {background:transparent}
+QAbstractScrollArea > .QWidget {background:transparent}
+QAbstractScrollArea > .QWidget > .QWidget {background:transparent}
+QMdiArea {qproperty-background:rgba(22, 23, 25, 1.000);border-radius:0}
+QMdiSubWindow {background:rgba(32, 33, 36, 1.000);border:1px solid;padding:0 3px}
+QMdiSubWindow > QWidget {border:1px solid rgba(63, 64, 66, 1.000)}
+QTextEdit, QPlainTextEdit {background:rgba(28, 29, 31, 1.000)}
+QTextEdit:focus,QTextEdit:selected,QPlainTextEdit:focus,QPlainTextEdit:selected {border:1px solid rgba(138, 180, 247, 1.000);selection-background-color:rgba(95, 154, 244, 0.400)}
+QTextEdit:!focus,QPlainTextEdit:!focus { selection-background-color:rgba(255, 255, 255, 0.125)}
+QTextEdit:!active,QPlainTextEdit:!active { }
+QAbstractItemView {padding:0;alternate-background-color:transparent;selection-background-color:transparent}
+QAbstractItemView:disabled {selection-background-color:transparent}
+QAbstractItemView::item:alternate,QAbstractItemView::branch:alternate {background:rgba(255, 255, 255, 0.047)}
+QAbstractItemView::item:selected,QAbstractItemView::branch:selected {background:rgba(66, 136, 242, 0.400)}
+QAbstractItemView::item:selected:!active,QAbstractItemView::branch:selected:!active {background:rgba(210, 227, 252, 0.150)}
+QAbstractItemView QLineEdit,QAbstractItemView QAbstractSpinBox,QAbstractItemView QAbstractButton {padding:0;margin:1px}
+QListView {padding:1px}
+QListView,QTreeView {background:rgba(32, 33, 36, 1.000)}
+QListView::item:!selected:hover,QTreeView::item:!selected:hover,QTreeView::branch:!selected:hover {background:rgba(255, 255, 255, 0.075)}
+QTreeView > QHeaderView {background:rgba(32, 33, 36, 1.000)}
+QTreeView > QHeaderView::section {background:rgba(63, 64, 66, 1.000)}
+QColumnView {background:rgba(32, 33, 36, 1.000)}
+QTableView {gridline-color:rgba(63, 64, 66, 1.000);background:rgba(16, 16, 18, 1.000); }
+QTableView:!active { selection-background-color:rgba(210, 227, 252, 0.180);}
+QTableView::item:alternate { background:rgba(255, 255, 255, 0.082);}
+QTableView::item:selected { background:rgba(66, 136, 242, 0.550);}
+QTableView QTableCornerButton::section {margin:0 1px 1px 0;background:rgba(63, 64, 66, 1.000);border-top-left-radius:2px}
+QTableView QTableCornerButton::section:pressed {background:rgba(66, 136, 242, 0.550)}
+QTableView > QHeaderView {background:rgba(16, 16, 18, 1.000);border-radius:3}
+QTableView > QHeaderView::section {background:rgba(63, 64, 66, 1.000)}
+QHeaderView {margin:0;border:none}
+QHeaderView::section {border:none;background:rgba(63, 64, 66, 1.000);padding-left:4px}
+QHeaderView::section:horizontal {margin-right:1px}
+QHeaderView::section:vertical {margin-bottom:1px}
+QHeaderView::section:on:enabled,QHeaderView::section:on:pressed {color:rgba(138, 180, 247, 1.000)}
+QHeaderView::section:last,QHeaderView::section:only-one {margin:0}
+QHeaderView::down-arrow:vertical,QHeaderView::up-arrow:vertical {width:0;height:0}
+QCalendarWidget > .QWidget {background:rgba(16, 16, 18, 1.000);border-bottom:1px solid rgba(63, 64, 66, 1.000);border-top-left-radius:4px;border-top-right-radius:4px}
+QCalendarWidget > .QWidget > QWidget {padding:1px}
+QCalendarWidget .QWidget > QToolButton {border-radius:4px}
+QCalendarWidget > QTableView {margin:0;border:none;border-radius:4px;border-top-left-radius:0;border-top-right-radius:0;alternate-background-color:rgba(255, 255, 255, 0.082); selection-background-color:rgba(66, 136, 242, 0.550);}
+QLineEdit,QAbstractSpinBox {padding:3px 4px;min-height:1em;border:1px solid rgba(63, 64, 66, 1.000);background:rgba(63, 64, 66, 1.000);border-radius:4px}
+QLineEdit:focus,QAbstractSpinBox:focus {border-color:rgba(138, 180, 247, 1.000)}
+QAbstractSpinBox::up-button,QAbstractSpinBox::down-button {subcontrol-position:center right;border-radius:4px}
+QAbstractSpinBox::up-button:hover:on,QAbstractSpinBox::down-button:hover:on {background:rgba(255, 255, 255, 0.145)}
+QAbstractSpinBox::up-button {bottom:5px;right:4px}
+QDateTimeEdit::down-arrow[calendarPopup=true] {image:none}
+QFileDialog QFrame {border:none}
+QFontDialog QListView {min-height:60px}
+QComboBox::indicator,QMenu::indicator {width:18px;height:18px}
+QMenu::indicator {background:rgba(255, 255, 255, 0.098);margin-left:3px;border-radius:4px}
+QCheckBox,QRadioButton {spacing:8px}
+QGroupBox::title,QAbstractItemView::item {spacing:6px}
+QCheckBox::indicator,QGroupBox::indicator,QAbstractItemView::indicator,QRadioButton::indicator {height:18px;width:18px}
+PlotWidget {padding:0}
+ParameterTree > .QWidget > .QWidget > .QWidget > QComboBox{min-height:1.2em}
+ParameterTree::item,ParameterTree > .QWidget {background:rgba(32, 33, 36, 1.000)}

--- a/mne_pipeline_hd/extra/light_stylesheet.txt
+++ b/mne_pipeline_hd/extra/light_stylesheet.txt
@@ -1,0 +1,182 @@
+QWidget {background:rgba(248, 249, 250, 1.000);color:rgba(77, 81, 87, 1.000);selection-color:rgba(77, 81, 87, 1.000);selection-background-color:rgba(97, 158, 239, 0.500)}
+QWidget:disabled {color:rgba(77, 81, 87, 0.400);selection-background-color:rgba(77, 81, 87, 0.250);selection-color:rgba(77, 81, 87, 0.400)}
+QWidget:focus {outline:none}
+QCheckBox:!window,QRadioButton:!window,QPushButton:!window,QLabel:!window,QLCDNumber:!window {background:transparent}
+QMdiSubWindow > QCheckBox:!window,QMdiSubWindow > QRadioButton:!window,QMdiSubWindow > QPushButton:!window,QMdiSubWindow > QLabel:!window,QMdiSubWindow > QLCDNumber:!window {background:rgba(248, 249, 250, 1.000)}
+QMainWindow::separator {width:4px;height:4px;background:rgba(218, 220, 224, 1.000)}
+QMainWindow::separator:hover,QMainWindow::separator:pressed {background:rgba(26, 115, 232, 1.000)}
+QToolTip {background:rgba(255, 255, 255, 1.000);color:rgba(77, 81, 87, 1.000)}
+QSizeGrip {width:0;height:0;image:none}
+QStatusBar {background:rgba(223, 225, 229, 1.000)}
+QStatusBar::item {border:none}
+QStatusBar QWidget {background:transparent;padding:3px;border-radius:4px}
+QStatusBar > .QSizeGrip {padding:0}
+QStatusBar QWidget:hover {background:rgba(0, 0, 0, 0.082)}
+QStatusBar QWidget:pressed,QStatusBar QWidget:checked {background:rgba(0, 0, 0, 0.141)}
+QCheckBox,QRadioButton {border-top:2px solid transparent;border-bottom:2px solid transparent}
+QCheckBox:hover,QRadioButton:hover {border-bottom:2px solid rgba(26, 115, 232, 1.000)}
+QGroupBox {font-weight:bold;margin-top:8px;padding:2px 1px 1px 1px;border-radius:4px;border:1px solid rgba(218, 220, 224, 1.000)}
+QGroupBox::title {subcontrol-origin:margin;subcontrol-position:top left;left:7px;margin:0 2px 0 3px}
+QGroupBox:flat {border-color:transparent}
+QMenuBar {padding:2px;border-bottom:1px solid rgba(218, 220, 224, 1.000);background:rgba(248, 249, 250, 1.000)}
+QMenuBar::item {background:transparent;padding:4px}
+QMenuBar::item:selected {padding:4px;border-radius:4px;background:rgba(0, 0, 0, 0.125)}
+QMenuBar::item:pressed {padding:4px;margin-bottom:0;padding-bottom:0}
+QToolBar {padding:1px;font-weight:bold;spacing:2px;margin:1px;background:rgba(235, 235, 235, 1.000);border-style:none}
+QToolBar::separator {background:rgba(218, 220, 224, 1.000)}
+QToolBar::separator:horizontal {width:2px;margin:0 6px}
+QToolBar::separator:vertical {height:2px;margin:6px 0}
+QToolBar > QToolButton {background:transparent;padding:3px;border-radius:4px}
+QToolBar > QToolButton:hover,QToolBar > QToolButton::menu-button:hover {background:rgba(0, 0, 0, 0.082)}
+QToolBar > QToolButton::menu-button {border-top-right-radius:4px;border-bottom-right-radius:4px}
+QToolBar > QToolButton:pressed,QToolBar > QToolButton::menu-button:pressed:enabled,QToolBar > QToolButton:checked:enabled {background:rgba(0, 0, 0, 0.141)}
+QToolBar > QWidget {background:transparent}
+QMenu {background:rgba(255, 255, 255, 1.000);padding:8px 0; }
+QMenu::separator {margin:4px 0;height:1px;background:rgba(218, 220, 224, 1.000)}
+QMenu::item {padding:4px 19px}
+QMenu::item:selected {background:rgba(0, 0, 0, 0.133)}
+QMenu::icon {padding-left:10px;width:14px;height:14px}
+QScrollBar {background:rgba(0, 0, 0, 0.063);border-radius:4px;}
+QScrollBar:horizontal {height:14px;}
+QScrollBar:vertical {width:14px;}
+QScrollBar::handle {background:rgba(0, 0, 0, 0.251);border-radius:3px}
+QScrollBar::handle:hover {background:rgba(0, 0, 0, 0.314)}
+QScrollBar::handle:pressed {background:rgba(0, 0, 0, 0.376)}
+QScrollBar::handle:disabled {background:rgba(0, 0, 0, 0.082)}
+QScrollBar::handle:horizontal {min-width:8px;margin:4px 14px;}
+QScrollBar::handle:horizontal:hover {margin:2px 14px;}
+QScrollBar::handle:vertical {min-height:8px;margin:14px 4px;}
+QScrollBar::handle:vertical:hover {margin:14px 2px;}
+QScrollBar::sub-page,QScrollBar::add-page {background:transparent}
+QScrollBar::sub-line,QScrollBar::add-line {background:transparent;}
+QProgressBar {text-align:center;border:1px solid rgba(218, 220, 224, 1.000);border-radius:4px}
+QProgressBar::chunk {background:rgba(73, 144, 237, 1.000);border-radius:3px}
+QProgressBar::chunk:disabled {background:rgba(77, 81, 87, 0.250)}
+QPushButton {color:rgba(26, 115, 232, 1.000);border:1px solid rgba(218, 220, 224, 1.000);padding:4px 8px;border-radius:4px}
+QPushButton:flat,QPushButton:default {border:none;padding:5px 9px}
+QPushButton:default {color:rgba(248, 249, 250, 1.000);background:rgba(26, 115, 232, 1.000)}
+QPushButton:hover {background:rgba(23, 112, 227, 0.100)}
+QPushButton:pressed {background:rgba(23, 112, 227, 0.240)}
+QPushButton:checked:enabled {background:rgba(23, 112, 227, 0.240)}
+QPushButton:default:hover {background:rgba(50, 130, 234, 1.000)}
+QPushButton:default:pressed,QPushButton:default:checked {background:rgba(97, 158, 239, 1.000)}
+QPushButton:default:disabled,QPushButton:default:checked:disabled {background:rgba(77, 81, 87, 0.250)}
+QDialogButtonBox {dialogbuttonbox-buttons-have-icons:0}
+QDialogButtonBox QPushButton {min-width:65px}
+QToolButton {background:transparent;padding:5px;spacing:2px;border-radius:2px}
+QToolButton:hover,QToolButton::menu-button:hover {background:rgba(23, 112, 227, 0.100)}
+QToolButton:pressed,QToolButton:checked:pressed,QToolButton::menu-button:pressed:enabled {background:rgba(23, 112, 227, 0.240)}
+QToolButton:selected:enabled,QToolButton:checked:enabled {background:rgba(23, 112, 227, 0.240)}
+QToolButton::menu-arrow {image:unset}
+QToolButton[popupMode="1"] {padding-right:1px;margin-right:18px;border-top-right-radius:0;border-bottom-right-radius:0}
+QComboBox {min-height:1.5em;padding:0 8px 0 4px;background:rgba(248, 249, 250, 1.000);border:1px solid rgba(218, 220, 224, 1.000);border-radius:4px}
+QComboBox:focus,QComboBox:open {border-color:rgba(26, 115, 232, 1.000)}
+QComboBox::drop-down {margin:2px 2px 2px -6px;border-radius:4}
+QComboBox::drop-down:editable:hover {background:rgba(0, 0, 0, 0.094)}
+QComboBox::item:selected {border:none;background:rgba(73, 144, 237, 0.350);border-radius:4px}
+QComboBox QListView[frameShape="0"] {margin:0;padding:4px;background:rgba(255, 255, 255, 1.000);selection-background-color:rgba(73, 144, 237, 0.350); border-radius:0; }
+QComboBox QListView::item {border-radius:4px}
+QSlider {padding:2px 0}
+QSlider::groove {border-radius:2px}
+QSlider::groove:horizontal {height:4px}
+QSlider::groove:vertical {width:4px}
+QSlider::sub-page:horizontal,QSlider::add-page:vertical,QSlider::handle {background:rgba(26, 115, 232, 1.000)}
+QSlider::sub-page:horizontal:disabled,QSlider::add-page:vertical:disabled,QSlider::handle:disabled {background:rgba(77, 81, 87, 0.250)}
+QSlider::add-page:horizontal,QSlider::sub-page:vertical {background:rgba(77, 81, 87, 0.200)}
+QSlider::handle:hover,QSlider::handle:pressed {background:rgba(73, 144, 237, 1.000)}
+QSlider::handle:horizontal {width:16px;height:8px;margin:-6px 0;border-radius:8px}
+QSlider::handle:vertical {width:8px;height:16px;margin:0 -6px;border-radius:8px}
+QTabWidget::pane {border:1px solid rgba(218, 220, 224, 1.000);border-radius:4px}
+QTabBar {qproperty-drawBase:0}
+QTabBar::close-button:hover {background:rgba(0, 0, 0, 0.125);border-radius:4px}
+QTabBar::tab {padding:3px;border-style:solid}
+QTabBar::tab:hover,QTabBar::tab:selected:hover:enabled {background:rgba(0, 0, 0, 0.082)}
+QTabBar::tab:selected:enabled {color:rgba(26, 115, 232, 1.000);background:rgba(0, 0, 0, 0.000);border-color:rgba(26, 115, 232, 1.000)}
+QTabBar::tab:selected:disabled,QTabBar::tab:only-one:selected:enabled {border-color:rgba(218, 220, 224, 1.000)}
+QTabBar::tab:top {border-bottom-width:2px;margin:3px 6px 0 0;border-top-left-radius:2px;border-top-right-radius:2px}
+QTabBar::tab:bottom {border-top-width:2px;margin:0 6px 3px 0;border-bottom-left-radius:2px;border-bottom-right-radius:2px}
+QTabBar::tab:left {border-right-width:2px;margin:0 0 6px 3px;border-top-left-radius:2px;border-bottom-left-radius:2px}
+QTabBar::tab:right {border-left-width:2px;margin-bottom:6px;margin:0 3px 6px 0;border-top-right-radius:2px;border-bottom-right-radius:2px}
+QTabBar::tab:top:first,QTabBar::tab:top:only-one,QTabBar::tab:bottom:first,QTabBar::tab:bottom:only-one {margin-left:2px}
+QTabBar::tab:top:last,QTabBar::tab:top:only-one,QTabBar::tab:bottom:last,QTabBar::tab:bottom:only-one {margin-right:2px}
+QTabBar::tab:left:first,QTabBar::tab:left:only-one,QTabBar::tab:right:first,QTabBar::tab:right:only-one {margin-top:2px}
+QTabBar::tab:left:last,QTabBar::tab:left:only-one,QTabBar::tab:right:last,QTabBar::tab:right:only-one {margin-bottom:2px}
+QDockWidget {border:1px solid rgba(218, 220, 224, 1.000);border-radius:4px}
+QDockWidget::title {padding:3px;spacing:4px;background:rgba(236, 239, 242, 1.000)}
+QDockWidget::close-button,QDockWidget::float-button {border-radius:2px}
+QDockWidget::close-button:hover,QDockWidget::float-button:hover {background:rgba(23, 112, 227, 0.100)}
+QDockWidget::close-button:pressed,QDockWidget::float-button:pressed {background:rgba(23, 112, 227, 0.240)}
+QFrame {border:1px solid rgba(218, 220, 224, 1.000);padding:1px;border-radius:4px}
+.QFrame {padding:0}
+QFrame[frameShape="0"] {border-color:transparent;padding:0}
+.QFrame[frameShape="0"] {border:none}
+QFrame[frameShape="2"] {border-color:rgba(255, 255, 255, 1.000);background:rgba(255, 255, 255, 1.000)}
+QFrame[frameShape="4"] {max-height:2px;border:none;background:rgba(218, 220, 224, 1.000)}
+QFrame[frameShape="5"] {max-width:2px;border:none;background:rgba(218, 220, 224, 1.000)}
+QLCDNumber {min-width:2em;margin:2px}
+QToolBox::tab {background:rgba(236, 239, 242, 1.000);border-bottom:2px solid rgba(218, 220, 224, 1.000);border-top-left-radius:4px;border-top-right-radius:4px}
+QToolBox::tab:selected:enabled {border-bottom-color:rgba(26, 115, 232, 1.000)}
+QSplitter::handle {background:rgba(218, 220, 224, 1.000);margin:1px 3px}
+QSplitter::handle:hover {background:rgba(26, 115, 232, 1.000)}
+QSplitterHandle::item:hover {}
+QAbstractScrollArea {margin:1px}
+QAbstractScrollArea::corner {background:transparent}
+QAbstractScrollArea > .QWidget {background:transparent}
+QAbstractScrollArea > .QWidget > .QWidget {background:transparent}
+QMdiArea {qproperty-background:rgba(255, 255, 255, 1.000);border-radius:0}
+QMdiSubWindow {background:rgba(248, 249, 250, 1.000);border:1px solid;padding:0 3px}
+QMdiSubWindow > QWidget {border:1px solid rgba(218, 220, 224, 1.000)}
+QTextEdit, QPlainTextEdit {background:rgba(255, 255, 255, 1.000)}
+QTextEdit:focus,QTextEdit:selected,QPlainTextEdit:focus,QPlainTextEdit:selected {border:1px solid rgba(26, 115, 232, 1.000);selection-background-color:rgba(97, 158, 239, 0.500)}
+QTextEdit:!focus,QPlainTextEdit:!focus { selection-background-color:rgba(0, 0, 0, 0.082)}
+QTextEdit:!active,QPlainTextEdit:!active { }
+QAbstractItemView {padding:0;alternate-background-color:transparent;selection-background-color:transparent}
+QAbstractItemView:disabled {selection-background-color:transparent}
+QAbstractItemView::item:alternate,QAbstractItemView::branch:alternate {background:rgba(0, 0, 0, 0.035)}
+QAbstractItemView::item:selected,QAbstractItemView::branch:selected {background:rgba(73, 144, 237, 0.350)}
+QAbstractItemView::item:selected:!active,QAbstractItemView::branch:selected:!active {background:rgba(13, 65, 133, 0.090)}
+QAbstractItemView QLineEdit,QAbstractItemView QAbstractSpinBox,QAbstractItemView QAbstractButton {padding:0;margin:1px}
+QListView {padding:1px}
+QListView,QTreeView {background:rgba(248, 249, 250, 1.000)}
+QListView::item:!selected:hover,QTreeView::item:!selected:hover,QTreeView::branch:!selected:hover {background:rgba(0, 0, 0, 0.075)}
+QTreeView::branch:!selected:hover,QTreeView::branch:alternate,QTreeView::branch:selected,QTreeView::branch:selected:!active { }
+QTreeView::branch:has-siblings:adjoins-item,QTreeView::branch:!has-children:!has-siblings:adjoins-item {border-image:unset}
+QTreeView > QHeaderView {background:rgba(248, 249, 250, 1.000)}
+QTreeView > QHeaderView::section {background:rgba(218, 220, 224, 1.000)}
+QColumnView {background:rgba(248, 249, 250, 1.000)}
+QTableView {gridline-color:rgba(218, 220, 224, 1.000);background:rgba(255, 255, 255, 1.000); }
+QTableView:!active { selection-background-color:rgba(13, 65, 133, 0.090);}
+QTableView::item:alternate { background:rgba(0, 0, 0, 0.071);}
+QTableView::item:selected { background:rgba(50, 130, 234, 0.500);}
+QTableView QTableCornerButton::section {margin:0 1px 1px 0;background:rgba(218, 220, 224, 1.000);border-top-left-radius:2px}
+QTableView QTableCornerButton::section:pressed {background:rgba(50, 130, 234, 0.500)}
+QTableView > QHeaderView {background:rgba(255, 255, 255, 1.000);border-radius:3}
+QTableView > QHeaderView::section {background:rgba(218, 220, 224, 1.000)}
+QHeaderView {margin:0;border:none}
+QHeaderView::section {border:none;background:rgba(218, 220, 224, 1.000);padding-left:4px}
+QHeaderView::section:horizontal {margin-right:1px}
+QHeaderView::section:vertical {margin-bottom:1px}
+QHeaderView::section:on:enabled,QHeaderView::section:on:pressed {color:rgba(26, 115, 232, 1.000)}
+QHeaderView::section:last,QHeaderView::section:only-one {margin:0}
+QHeaderView::down-arrow:vertical,QHeaderView::up-arrow:vertical {width:0;height:0}
+QCalendarWidget > .QWidget {background:rgba(255, 255, 255, 1.000);border-bottom:1px solid rgba(218, 220, 224, 1.000);border-top-left-radius:4px;border-top-right-radius:4px}
+QCalendarWidget > .QWidget > QWidget {padding:1px}
+QCalendarWidget .QWidget > QToolButton {border-radius:4px}
+QCalendarWidget > QTableView {margin:0;border:none;border-radius:4px;border-top-left-radius:0;border-top-right-radius:0;alternate-background-color:rgba(0, 0, 0, 0.071); selection-background-color:rgba(50, 130, 234, 0.500);}
+QLineEdit,QAbstractSpinBox {padding:3px 4px;min-height:1em;border:1px solid rgba(218, 220, 224, 1.000);background:rgba(248, 249, 250, 1.000);border-radius:4px}
+QLineEdit:focus,QAbstractSpinBox:focus {border-color:rgba(26, 115, 232, 1.000)}
+QAbstractSpinBox::up-button,QAbstractSpinBox::down-button {subcontrol-position:center right;border-radius:4px}
+QAbstractSpinBox::up-button:hover:on,QAbstractSpinBox::down-button:hover:on {background:rgba(0, 0, 0, 0.094)}
+QAbstractSpinBox::up-button {bottom:5px;right:4px}
+QAbstractSpinBox::down-button {top:5px;right:4px}
+QDateTimeEdit::down-arrow[calendarPopup=true] {image:none}
+QFileDialog QFrame {border:none}
+QFontDialog QListView {min-height:60px}
+QComboBox::indicator,QMenu::indicator {width:18px;height:18px}
+QMenu::indicator {background:rgba(0, 0, 0, 0.098);margin-left:3px;border-radius:4px}
+QCheckBox,QRadioButton {spacing:8px}
+QGroupBox::title,QAbstractItemView::item {spacing:6px}
+QCheckBox::indicator,QGroupBox::indicator,QAbstractItemView::indicator,QRadioButton::indicator {height:18px;width:18px}
+PlotWidget {padding:0}
+ParameterTree > .QWidget > .QWidget > .QWidget > QComboBox{min-height:1.2em}
+ParameterTree::item,ParameterTree > .QWidget {background:rgba(248, 249, 250, 1.000)}

--- a/mne_pipeline_hd/extra/pyqtdarktheme_license.txt
+++ b/mne_pipeline_hd/extra/pyqtdarktheme_license.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021-2022 Yunosuke Ohsugi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/mne_pipeline_hd/pipeline/legacy.py
+++ b/mne_pipeline_hd/pipeline/legacy.py
@@ -46,11 +46,11 @@ renamed_parameters = {
 }
 
 # New packages with {import_name: install_name} (can be the same)
-new_packages = {"qdarktheme": "pyqtdarktheme"}
+new_packages = {"darkdetect": "darkdetect"}
 
 
 def install_package(package_name):
-    logger().info(f"Installing {package_name}...")
+    print(f"Installing {package_name}...")
     print(
         subprocess.check_output(
             [sys.executable, "-m", "pip", "install", package_name], text=True
@@ -59,7 +59,7 @@ def install_package(package_name):
 
 
 def uninstall_package(package_name):
-    logger().info(f"Uninstalling {package_name}...")
+    print(f"Uninstalling {package_name}...")
     print(
         subprocess.check_output(
             [sys.executable, "-m", "pip", "uninstall", "-y", package_name], text=True
@@ -80,9 +80,7 @@ def legacy_import_check(test_package=None):
         try:
             __import__(import_name)
         except ImportError:
-            logger().info(
-                f"The package {import_name} " f"is required for this application.\n"
-            )
+            print(f"The package {import_name} " f"is required for this application.\n")
             ans = input("Do you want to install the " "new package now? [y/n]").lower()
             if ans == "y":
                 try:
@@ -91,7 +89,7 @@ def legacy_import_check(test_package=None):
                     logger().critical("Installation failed!")
                 else:
                     return
-            logger().info(
+            print(
                 f"Please install the new package {import_name} "
                 f"manually with:\n\n"
                 f"> pip install {install_name}"
@@ -102,7 +100,7 @@ def legacy_import_check(test_package=None):
 def transfer_file_params_to_single_subject(ct):
     old_fp_path = join(ct.pr.pscripts_path, f"file_parameters_{ct.pr.name}.json")
     if isfile(old_fp_path):
-        logger().info("Transfering File-Parameters to single files...")
+        print("Transfering File-Parameters to single files...")
         with open(old_fp_path, "r") as file:
             file_parameters = json.load(file, object_hook=type_json_hook)
             for obj_name in file_parameters:
@@ -121,4 +119,4 @@ def transfer_file_params_to_single_subject(ct):
                     obj.save_file_parameter_file()
                     obj.clean_file_parameters()
         os.remove(old_fp_path)
-        logger().info("Done!")
+        print("Done!")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "h5netcdf",
     # PyQt
     "qtpy",
-    "pyqtdarktheme",
+    "darkdetect",
     "pyobjc-framework-Cocoa; sys_platform == 'Darwin'",
     # Other
     "psutil",


### PR DESCRIPTION
This takes the stylesheets from [PyQtDarktheme](https://github.com/5yutan5/PyQtDarkTheme) and includes the license. Thanks to the developer.
This avoids future problems with incompatibility of Python/PyQt-versions.